### PR TITLE
Provide `--full-paths` option to browerify in third example

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -54,7 +54,7 @@ $ module-deps x.js y.js | factor-bundle \
 or factor out an existing bundle already compiled by browserify:
 
 ``` sh
-$ browserify x.js y.js > bundle.js
+$ browserify --full-paths x.js y.js > bundle.js
 $ browser-unpack < bundle.js | factor-bundle \
   x.js -o bundle/x.js \
   y.js -o bundle/y.js \


### PR DESCRIPTION
This option creates the `module-deps` output using the full path of the module.
Without this, factor-bundle cannot correspond the module id to the actual module.