### PR TITLE
Fix for factor-bundle + watchify + gulp 'EventEmitter memory leak detected' issue

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,7 +52,7 @@ module.exports = function f (b, opts) {
           hasExports: true
         });
 
-    b.on('reset', addHooks);
+    b.once('reset', addHooks);
     addHooks();
 
     function addHooks () {


### PR DESCRIPTION
Implemented the fix for #64 suggested by @Freyert