### PR TITLE
reconstruct outputs every `addHooks` (to make it compatible with watchify)

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,7 +28,14 @@ module.exports = function f (b, opts) {
     var needRecords = !files.length;
     
     var outopt = defined(opts.outputs, opts.output, opts.o);
-    
+
+    function moreOutputs (file) {
+        if (isarray(outopt)) return [];
+        if (!outopt) return [];
+        var xopts = { env: xtend(process.env, { FILE: file }) };
+        return [ outpipe(outopt, xopts) ];
+    }
+
     opts.objectMode = true;
     opts.raw = true;
     opts.rmap = {};
@@ -51,13 +58,6 @@ module.exports = function f (b, opts) {
             });
         } else {
             outputs = [];
-        }
-
-        function moreOutputs (file) {
-            if (isarray(outopt)) return [];
-            if (!outopt) return [];
-            var xopts = { env: xtend(process.env, { FILE: file }) };
-            return [ outpipe(outopt, xopts) ];
         }
 
         b.pipeline.get('record').push(through.obj(function(row, enc, next) {

--- a/test/outputs.js
+++ b/test/outputs.js
@@ -7,15 +7,17 @@ var mkdirp = require('mkdirp');
 var browserify = require('browserify');
 var factor = require('../');
 var concat = require('concat-stream');
+var through = require('through2');
 
 var files = [
     __dirname + '/deps/x.js',
     __dirname + '/deps/y.js'
 ];
-var tmpdir = tmp() + '/factor-bundle-' + Math.random();
-mkdirp.sync(tmpdir);
 
 test('file outputs', function (t) {
+    var tmpdir = tmp() + '/factor-bundle-' + Math.random();
+    mkdirp.sync(tmpdir);
+
     t.plan(2);
     var b = browserify(files);
     b.plugin(factor, {
@@ -43,6 +45,9 @@ test('file outputs', function (t) {
 });
 
 test('stream outputs', function (t) {
+    var tmpdir = tmp() + '/factor-bundle-' + Math.random();
+    mkdirp.sync(tmpdir);
+
     t.plan(2);
     var sources = {}, pending = 3;
     function write (key) {
@@ -68,3 +73,76 @@ test('stream outputs', function (t) {
         } } });
     }
 });
+
+test('bundle twice', function (t) {
+    var tmpdir = tmp() + '/factor-bundle-' + Math.random();
+    mkdirp.sync(tmpdir);
+
+    t.plan(4);
+    var b = browserify(files);
+    var outputs = [
+        path.join(tmpdir, 'x.js'),
+        path.join(tmpdir, 'y.js')
+    ];
+    b.on('reset', function(){
+        b.pipeline.get('deps').push(through.obj(function(data, enc, next){
+            if (data.file.indexOf('x.js') !== -1) {
+                data.source = data.source.replace('z(5)', 'z(6)');
+            }
+            this.push(data);
+            next();
+        }));
+    });
+    b.plugin(factor, {
+        outputs: outputs
+    });
+    validate(55500, 333, function(){
+        validate(66600, 333);
+    });
+    function validate (xVal, yVal, cb) {
+        var w = fs.createWriteStream(path.join(tmpdir, 'common.js'));
+        b.bundle().pipe(w);
+        w.on('finish', function(){
+            var common = fs.readFileSync(tmpdir + '/common.js', 'utf8');
+            var x = fs.readFileSync(tmpdir + '/x.js', 'utf8');
+            var y = fs.readFileSync(tmpdir + '/y.js', 'utf8');
+            
+            vm.runInNewContext(common + x, { console: { log: function (msg) {
+                t.equal(msg, xVal);
+            } } });
+            
+            vm.runInNewContext(common + y, { console: { log: function (msg) {
+                t.equal(msg, yVal);
+            } } });
+            if (cb) cb();
+        });
+    }
+});
+
+test('outpipe outputs', function (t) {
+    var tmpdir = tmp() + '/factor-bundle-' + Math.random();
+    mkdirp.sync(tmpdir);
+
+    t.plan(2);
+    var b = browserify(files);
+    b.plugin(factor, {
+        output: ' cat > ' + tmpdir + '/`basename $FILE`'
+    });
+    var w = fs.createWriteStream(path.join(tmpdir, 'common.js'));
+    b.bundle().pipe(w);
+    
+    w.on('finish', function () {
+        var common = fs.readFileSync(tmpdir + '/common.js', 'utf8');
+        var x = fs.readFileSync(tmpdir + '/x.js', 'utf8');
+        var y = fs.readFileSync(tmpdir + '/y.js', 'utf8');
+        
+        vm.runInNewContext(common + x, { console: { log: function (msg) {
+            t.equal(msg, 55500);
+        } } });
+        
+        vm.runInNewContext(common + y, { console: { log: function (msg) {
+            t.equal(msg, 333);
+        } } });
+    });
+});
+


### PR DESCRIPTION
fix #68, #63 

- To avoid writing to ended writeStream, outputs will be constructed everytime
- In the scenario that user wanna use outpipe, the `outopt` will be
kept as string, so we can determine the user's attempt in later codes
and do the relavant opperations