### PR TITLE
support callback outputs

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -193,6 +193,7 @@ The output format for `fr` and each of the `fr` sub-streams given by each
 `opts.o` or `opts.outputs` should be an array that pairs up with the `files` array to specify
 where each bundle output for each entry file should be written. The elements in
 `opts.o` can be string filenames or writable streams.
+`opts.o` (version > 2.4.1) can be a callback which receives the `files` array, and should return the paired `outputs` array.
 
 `opts.entries` or `opts.e` should be the array of entry files to create
 a page-specific bundle for each file. If you don't pass in an `opts.entries`,
@@ -236,6 +237,12 @@ Emits the full path to the entry file (`file`) and a [labeled-stream-splicer](ht
 You can call `pipeline.get` with a label name to get a handle on a stream pipeline that you can `push()`, `unshift()`, or `splice()` to insert your own transform streams.
 
 Event handlers must be attached *before* calling `b.plugin`.
+
+## b.on('factor.pipelines', function (files, pipelines, outputs) {})
+
+Instead of emitting pipelines one by one like `factor.pipeline` event does, this event emits all the pipelines.
+In addition, this event also emits all the output streams.
+`files`, `pipelines`, `outputs` are all instances of `Array`.
 
 # install
 

--- a/test/outputs.js
+++ b/test/outputs.js
@@ -68,3 +68,32 @@ test('stream outputs', function (t) {
         } } });
     }
 });
+
+test('callback outputs', function (t) {
+    t.plan(2);
+    var sources = {}, pending = 3;
+    function write (key) {
+        return concat(function (body) {
+            sources[key] = body.toString('utf8');
+            if (-- pending === 0) done();
+        });
+    }
+
+    var b = browserify(files);
+    b.plugin(factor, { outputs: function () {
+        return [ write('x'), write('y') ];
+    }});
+    b.bundle().pipe(write('common'));
+
+    function done () {
+        var common = sources.common, x = sources.x, y = sources.y;
+
+        vm.runInNewContext(common + x, { console: { log: function (msg) {
+            t.equal(msg, 55500);
+        } } });
+
+        vm.runInNewContext(common + y, { console: { log: function (msg) {
+            t.equal(msg, 333);
+        } } });
+    }
+});


### PR DESCRIPTION
I was trying to use watchify + factor-bundle + gulp, and it didn't work because the output streams ended before `reset`, and thus not writable.

I searched the issues, and found https://github.com/substack/factor-bundle/pull/25. There is a nice solution for factor-bundle with gulp, but watchify still the problem.

So, here is my solution. I am not quite sure it is the right way, but it seems to work.

Perhaps the `outputs` can be generated each time `addHooks` run to make sure writable outputs.
As the `outputs` element could be streams, they should also be reconstructed, and factor-bundle lacks that information right now. So, here comes the `callback outputs` .

Here is an example: https://github.com/zoubin/watchify-factor-bundle-gulp
