### PR TITLE
Outputs as function, and reconstruct each addHooks

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,19 +67,22 @@ module.exports = function f (b, opts) {
             }
             next(null, row);
         }, function(next) {
+            var outputResult;
+
+            if (typeof outputs === 'function') {
+                outputResult = outputs();
+            } else outputResult = outputs;
+
             var pipelines = files.reduce(function (acc, x, ix) {
                 var pipeline = splicer.obj([
                     'pack', [ pack(packOpts) ],
                     'wrap', []
                 ]);
-                if (typeof outputs === 'function') {
-                    pipeline.pipe(outputs(x))
-                } else {
-                    if (ix >= outputs.length) {
-                        outputs.push.apply(outputs, moreOutputs(x));
-                    }
-                    if (outputs[ix]) pipeline.pipe(outputs[ix]);
+
+                if (ix >= outputResult.length) {
+                    outputResult.push.apply(outputResult, moreOutputs(x));
                 }
+                if (outputResult[ix]) pipeline.pipe(outputResult[ix]);
                 
                 acc[path.resolve(cwd, x)] = pipeline;
                 return acc;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "factor-bundle",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "description": "factor browser-pack bundles into common shared bundles",
   "main": "index.js",
   "bin": "bin/cmd.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "factor-bundle",
-  "version": "2.4.2",
+  "version": "2.5.0",
   "description": "factor browser-pack bundles into common shared bundles",
   "main": "index.js",
   "bin": "bin/cmd.js",

--- a/readme.markdown
+++ b/readme.markdown
@@ -140,6 +140,7 @@ where OPTIONS are:
 
   -o  Output FILE or CMD that maps to a corresponding entry file at the same
       index. CMDs are executed with $FILE set to the corresponding input file.
+      Optionally specify a function that return a writable stream.
  
   -e  Entry file to use, overriding the entry files listed in the original
       bundle.

--- a/readme.markdown
+++ b/readme.markdown
@@ -140,7 +140,7 @@ where OPTIONS are:
 
   -o  Output FILE or CMD that maps to a corresponding entry file at the same
       index. CMDs are executed with $FILE set to the corresponding input file.
-      Optionally specify a function that return a writable stream.
+      Optionally specify a function that returns a valid value for this argument.
  
   -e  Entry file to use, overriding the entry files listed in the original
       bundle.


### PR DESCRIPTION
This is a combination of #71 and the idea of allowing outputs to be a function (as seen in https://github.com/Aben/factor-bundle/commit/18692d69d983470857d6d3c6af7b7bd12266714f, with a signature change), to fix #63 so that factor-bundle can work with watchify.

#71 fixes the issue for string outputs but not for stream outputs. In order to fix it for stream outputs, we need to be able to specify a function for outputs that creates new streams each time `.bundle` is called on the browserify instance. That is, unless you have a better idea, @substack 

Includes tests from #71 and an additional test for output option as a function.

If the outputs option is specified as a function, the function should take no arguments and return a valid (non-function) value for the outputs option. e.g. an array of strings. Simple.

All tests passing, version bumped to 2.5.0.