### PR TITLE
update browser pack to ^6

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "bin": "bin/cmd.js",
   "dependencies": {
     "JSONStream": "~0.8.4",
-    "browser-pack": "^5.0.1",
+    "browser-pack": "^6.0.1",
     "defined": "0.0.0",
     "deps-topo-sort": "~0.2.1",
     "inherits": "^2.0.1",


### PR DESCRIPTION
browser-pack v5 creates inline source maps with output `charset:` whereas v6 outputs `charset=`, which seems to work better in general (and is the one browserify is currently using).
